### PR TITLE
Make sure command is called in a clean environment

### DIFF
--- a/lib/motion.h.rb
+++ b/lib/motion.h.rb
@@ -68,7 +68,9 @@ class MotionHeader
         "--64-bit"
       end
     end
-    `/Library/RubyMotion/bin/gen_bridge_metadata --format complete #{flag} --cflags '-I#{include_path} -F#{frameworks_path}' #{@header_file} > #{bridgesupport_file}`
+    Bundler.with_clean_env do
+      `/Library/RubyMotion/bin/gen_bridge_metadata --format complete #{flag} --cflags '-I#{include_path} -F#{frameworks_path}' #{@header_file} > #{bridgesupport_file}`
+    end
   end
 
   def include_path


### PR DESCRIPTION
Make sure command is called in a clean environment to avoid strange issues with missing gems since we're shelling out to use system Ruby.